### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/flask_customer_segmentation.py
+++ b/flask_customer_segmentation.py
@@ -3,6 +3,7 @@ import joblib
 import pandas as pd
 import numpy as np
 from sklearn.preprocessing import StandardScaler
+import traceback
 
 # Load the saved models
 kmeans = joblib.load("kmeans_model.pkl")
@@ -41,7 +42,8 @@ def predict():
         
         return jsonify({'clusters': clusters.tolist()})
     except Exception as e:
-        return jsonify({'error': str(e)})
+        app.logger.error(traceback.format_exc())
+        return jsonify({'error': 'An internal error has occurred!'})
 
 # Run the app
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/project_005/security/code-scanning/1](https://github.com/venkateshpabbati/project_005/security/code-scanning/1)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling in the `/predict` route.

1. Import the `traceback` module to capture the stack trace.
2. Log the detailed error message using `traceback.format_exc()`.
3. Return a generic error message to the user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
